### PR TITLE
Malicious site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package contains a Markdown editor form field to be used in [Filament](http
 
 ![screenshot](https://github.com/spatie/filament-markdown-editor/blob/main/docs/editor.jpg?raw=true)
 
-The Markdown field is powered by [EasyMDE](https://easy-markdown-editor.tk).
+The Markdown field is powered by [EasyMDE](https://github.com/Ionaru/easy-markdown-editor).
 
 ## Support us
 


### PR DESCRIPTION
The link to the demo version of EasyMDE specified in the Readme leads to a malicious site. It may be worth replacing it with a link to the Github repository.

Offtop. Have you thought about adding a full-screen view? It was very helpful.