### PR TITLE
Allow multiple editors on same page

### DIFF
--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -25,7 +25,8 @@
     <div
         x-data="{ state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }} }"
         x-init="
-            editor = new EasyMDE({
+            window.SpatieMarkdownFields = window.SpatieMarkdownFields || {};
+            window.SpatieMarkdownFields['{{$getStatePath()}}'] = new EasyMDE({
                 autoDownloadFontAwesome: false,
                 element: $refs.editor,
                 uploadImage: true,
@@ -102,9 +103,9 @@
                     });
                 },
             });
-            
+
             // 'Create Link (Ctrl-K)': highlight URL instead of label:
-            editor.codemirror.on('changes', (instance, changes) => {
+            window.SpatieMarkdownFields['{{$getStatePath()}}'].codemirror.on('changes', (instance, changes) => {
                 try {
                     // Grab the last change from the buffered list. I assume the
                     // buffered one ('changes', instead of 'change') is more efficient,
@@ -138,16 +139,16 @@
                 }
             });
 
-            editor.codemirror.on('change', debounce(() => {
-                state = editor.value();
+            window.SpatieMarkdownFields['{{$getStatePath()}}'].codemirror.on('change', debounce(() => {
+                state = window.SpatieMarkdownFields['{{$getStatePath()}}'].value();
             }));
 
             $watch('state', () => {
-                if (editor.codemirror.hasFocus()) {
+                if (window.SpatieMarkdownFields['{{$getStatePath()}}'].codemirror.hasFocus()) {
                     return;
                 }
 
-                editor.value(state ?? '');
+                window.SpatieMarkdownFields['{{$getStatePath()}}'].value(state ?? '');
             });
         "
         wire:ignore

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -23,10 +23,9 @@
     </script>
 
     <div
-        x-data="{ state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }} }"
+        x-data="{ state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }}, editor: null }"
         x-init="
-            window.SpatieMarkdownFields = window.SpatieMarkdownFields || {};
-            window.SpatieMarkdownFields['{{$getStatePath()}}'] = new EasyMDE({
+            editor = new EasyMDE({
                 autoDownloadFontAwesome: false,
                 element: $refs.editor,
                 uploadImage: true,
@@ -103,9 +102,9 @@
                     });
                 },
             });
-
+            
             // 'Create Link (Ctrl-K)': highlight URL instead of label:
-            window.SpatieMarkdownFields['{{$getStatePath()}}'].codemirror.on('changes', (instance, changes) => {
+            editor.codemirror.on('changes', (instance, changes) => {
                 try {
                     // Grab the last change from the buffered list. I assume the
                     // buffered one ('changes', instead of 'change') is more efficient,
@@ -139,16 +138,16 @@
                 }
             });
 
-            window.SpatieMarkdownFields['{{$getStatePath()}}'].codemirror.on('change', debounce(() => {
-                state = window.SpatieMarkdownFields['{{$getStatePath()}}'].value();
+            editor.codemirror.on('change', debounce(() => {
+                state = editor.value();
             }));
 
             $watch('state', () => {
-                if (window.SpatieMarkdownFields['{{$getStatePath()}}'].codemirror.hasFocus()) {
+                if (editor.codemirror.hasFocus()) {
                     return;
                 }
 
-                window.SpatieMarkdownFields['{{$getStatePath()}}'].value(state ?? '');
+                editor.value(state ?? '');
             });
         "
         wire:ignore


### PR DESCRIPTION
Hi Spatie team,

Currently when we have multiple editors on the same page, the behavior is not good since it is the value of the last editor that is saved for all the editors.

~~introducing a global variable corrects this problem.~~

EDIT: a better solution with alpine seems to be to declare `editor` in x-data to scope the variable for children only.