### PR TITLE
Fix issue where field is persisted after deleting a block

### DIFF
--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -147,7 +147,7 @@
                     return;
                 }
 
-                editor.value(state ?? '');
+                editor.value(state ?? null);
             });
         "
         wire:ignore


### PR DESCRIPTION
This fixes an issue that ultimately results in this error message: https://github.com/filamentphp/filament/issues/7450.

When using filament-markdown-editor with the `Builder` field (https://filamentphp.com/docs/2.x/forms/fields#builder) the following bug can be consistently triggered:

1. Add a block with a markdown field
2. Set some content in the markdown field
3. Save (or don't)
4. Reload (or dont')
5. Delete the block
6. Save

This will trigger this error message https://github.com/filamentphp/filament/issues/7450. The block is deleted, however the field (in my case called `content`) will still have a value of `''` meaning the block is not completely empty; it is now an array `["content" => ""]` and we get an error. The workround suggested in issue 7450 doesn't work because this will lead to actually _storing_ `["content" => ""]`.

Anyway. I hope I get this across, I'm not too familiar with the inner workings of livewire, but this change does fix the issue.