### PR TITLE
Adds laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
-        laravel: [10.*, 9.*]
+        laravel: [9.*, 10.*, 11.*]
         filament: [2.*, 3.*]
         stability: [prefer-stable]
         include:
@@ -24,6 +24,11 @@ jobs:
             testbench: 7.*
           - laravel: 10.*
             filament: 3.*
+          - laravel: 11.*
+            testbench: 9.*
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
         laravel: [9.*, 10.*, 11.*]
-        filament: [2.*, 3.*]
+        filament: [3.*]
         stability: [prefer-stable]
         include:
           - laravel: 10.*

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^2.16.31|^3.0",
+        "filament/filament": "^3.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.13.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^2.16.31|^3.0",
-        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.13.6"
     },
     "require-dev": {
         "laravel/pint": "^1.2",
-        "nunomaduro/collision": "^6.3.1",
-        "orchestra/testbench": "^7.10.1|^8.0",
-        "pestphp/pest": "^1.22.1",
-        "pestphp/pest-plugin-laravel": "^1.3",
-        "phpunit/phpunit": "^9.5.25"
+        "nunomaduro/collision": "^6.3.1|^8.0",
+        "orchestra/testbench": "^7.10.1|^8.0|^9.0",
+        "pestphp/pest": "^1.22.1|^2.34",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.3",
+        "phpunit/phpunit": "^9.5.25|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -1,4 +1,4 @@
-<x-forms::field-wrapper
+<x-filament-forms::field-wrapper
     :id="$getId()"
     :label="$getLabel()"
     :label-sr-only="$isLabelHidden()"
@@ -154,4 +154,4 @@
     >
         <textarea x-ref="editor"></textarea>
     </div>
-</x-forms::field-wrapper>
+</x-filament-forms::field-wrapper>

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -4,7 +4,6 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
-    :hint-action="$getHintAction()"
     :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
@@ -92,7 +91,7 @@
                     }
 
                     $wire.upload(`componentFileAttachments.{{ $getStatePath() }}`, file, () => {
-                        $wire.getComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
+                        $wire.getFormComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
                             if (! url) {
                                 return onError('File could not be uploaded');
                             }

--- a/src/MarkdownEditorServiceProvider.php
+++ b/src/MarkdownEditorServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\FilamentMarkdownEditor;
 
-use Filament\Facades\Filament;
+use Filament\Support\Assets\Css;
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -16,16 +18,12 @@ class MarkdownEditorServiceProvider extends PackageServiceProvider
             ->hasViews();
     }
 
-    public function bootingPackage()
+    public function bootingPackage(): void
     {
-        Filament::registerScripts([
-            'spatie-markdown-editor' => __DIR__.'/../resources/dist/editor.js',
-        ], true);
-
-        Filament::registerStyles([
-            'https://pro.fontawesome.com/releases/v5.15.4/css/all.css',
-            'https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css',
-            'spatie-markdown-editor' => __DIR__.'/../resources/css/editor.css',
+        FilamentAsset::register([
+            Js::make('spatie-markdown-editor', __DIR__.'/../resources/dist/editor.js'),
+            Css::make('font-awesome', 'https://pro.fontawesome.com/releases/v5.15.4/css/all.css'),
+            Css::make('spatie-markdown-editor', __DIR__.'/../resources/css/editor.css'),
         ]);
     }
 }


### PR DESCRIPTION
Hi @freekmurze 👋 

I'm opening this to continue the work started by Laravel Shift on https://github.com/spatie/filament-markdown-editor/pull/24 to add Laravel 11 support. I am not sure how to continue the work on the same PR, or if that's possible (https://github.com/spatie/filament-markdown-editor/pull/24#issuecomment-2002397783), so I opened a new one. Feel free to just to copy the code to the original PR if you prefer.

I also dropped support for Filament v2