### PR TITLE
Filament v3 support - drop filament v2 support - add laravel v11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
-        laravel: [10.*, 9.*]
+        laravel: [9.*, 10.*, 11.*]
         filament: [2.*, 3.*]
         stability: [prefer-stable]
         include:
@@ -24,6 +24,11 @@ jobs:
             testbench: 7.*
           - laravel: 10.*
             filament: 3.*
+          - laravel: 11.*
+            testbench: 9.*
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
         laravel: [9.*, 10.*, 11.*]
-        filament: [2.*, 3.*]
+        filament: [3.*]
         stability: [prefer-stable]
         include:
           - laravel: 10.*

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^2.16.31|^3.0",
+        "filament/filament": "^3.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.13.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^2.16.31|^3.0",
-        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.13.6"
     },
     "require-dev": {
         "laravel/pint": "^1.2",
-        "nunomaduro/collision": "^6.3.1",
-        "orchestra/testbench": "^7.10.1|^8.0",
-        "pestphp/pest": "^1.22.1",
-        "pestphp/pest-plugin-laravel": "^1.3",
-        "phpunit/phpunit": "^9.5.25"
+        "nunomaduro/collision": "^6.3.1|^8.0",
+        "orchestra/testbench": "^7.10.1|^8.0|^9.0",
+        "pestphp/pest": "^1.22.1|^2.34",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.3",
+        "phpunit/phpunit": "^9.5.25|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -41,3 +41,11 @@
 .cm-attribute {color: #00c;}
 .cm-hr {color: #999;}
 .cm-link {color: #00c;}
+
+/* Remove the .EasyMDEContainer button mask images set by filament in favour of font awesome icons */
+.spatie-filament-markdown-editor .EasyMDEContainer .editor-toolbar button::before {
+    mask: unset;
+    width: unset;
+    height: unset;
+    background: unset;
+}

--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -41,12 +41,3 @@
 .cm-attribute {color: #00c;}
 .cm-hr {color: #999;}
 .cm-link {color: #00c;}
-
-.EasyMDEContainer {
-    padding-top: 1px;
-}
-
-.EasyMDEContainer .editor-toolbar {
-    border-top: 1px solid #ced4da;
-    border-bottom: 1px solid #ced4da;
-}

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -1,14 +1,4 @@
-<x-filament-forms::field-wrapper
-    :id="$getId()"
-    :label="$getLabel()"
-    :label-sr-only="$isLabelHidden()"
-    :helper-text="$getHelperText()"
-    :hint="$getHint()"
-    :hint-color="$getHintColor()"
-    :hint-icon="$getHintIcon()"
-    :required="$isRequired()"
-    :state-path="$getStatePath()"
->
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <script>
         function debounce(func, timeout = 300) {
             let timer;
@@ -21,136 +11,138 @@
         }
     </script>
 
-    <div
-        x-data="{ state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }}, editor: null }"
-        x-init="
-            editor = new EasyMDE({
-                autoDownloadFontAwesome: false,
-                element: $refs.editor,
-                uploadImage: true,
-                placeholder: @js(__($getPlaceholder() ?? 'Start writing…')),
-                initialValue: state ?? '',
-                spellChecker: false,
-                autoSave: false,
-                status: [{
-                    className: 'upload-image',
-                    defaultValue: ''
-                }],
-                toolbar: [
-                @if($hasToolbarButton('heading'))
-                    'heading',
-                @endif
-                @if($hasToolbarButton('bold'))
-                    'bold',
-                @endif
-                @if($hasToolbarButton('italic'))
-                    'italic',
-                @endif
-                @if($hasToolbarButton('link'))
-                    'link',
-                @endif
-                @if($hasToolbarButton('quote'))
-                    'quote',
-                @endif
-                @if($hasToolbarButton('unordered-list'))
-                    'unordered-list',
-                @endif
-                @if($hasToolbarButton('ordered-list'))
-                    'ordered-list',
-                @endif
-                @if($hasToolbarButton('table'))
-                    'table',
-                @endif
-                @if($hasToolbarButton('upload-image'))
-                    {
-                        name: 'upload-image',
-                        action: EasyMDE.drawUploadedImage,
-                        className: 'fa fa-image',
-                    },
-                @endif
-                @if($hasToolbarButton('undo'))
-                    'undo',
-                @endif
-                @if($hasToolbarButton('redo'))
-                    { // When FontAwesome is not auto downloaded, this loads the correct icon
-                        name: 'redo',
-                        action: EasyMDE.redo,
-                        className: 'fa fa-redo',
-                        title: 'Redo',
-                    },
-                @endif
-                ],
-                imageAccept: 'image/png, image/jpeg, image/gif, image/avif',
-                imageUploadFunction: function(file, onSuccess, onError) {
-                    if (file.size > 1024 * 1024 * 2) {
-                        return onError('File cannot be larger than 2MB.');
-                    }
-
-                    if (file.type.split('/')[0] !== 'image') {
-                        return onError('File must be an image.');
-                    }
-
-                    $wire.upload(`componentFileAttachments.{{ $getStatePath() }}`, file, () => {
-                        $wire.getFormComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
-                            if (! url) {
-                                return onError('File could not be uploaded');
-                            }
-
-                            onSuccess(url);
-                        })
-                    });
-                },
-            });
-            
-            // 'Create Link (Ctrl-K)': highlight URL instead of label:
-            editor.codemirror.on('changes', (instance, changes) => {
-                try {
-                    // Grab the last change from the buffered list. I assume the
-                    // buffered one ('changes', instead of 'change') is more efficient,
-                    // and that 'Create Link' will always end up last in the list.
-                    const lastChange = changes[changes.length - 1];
-                    if (lastChange.origin === '+input') {
-                        // https://github.com/Ionaru/easy-markdown-editor/blob/8fa54c496f98621d5f45f57577ce630bee8c41ee/src/js/easymde.js#L765
-                        const EASYMDE_URL_PLACEHOLDER = '(https://)';
-                        // The URL placeholder is always placed last, so just look at the
-                        // last text in the array to also cover the multi-line case:
-                        const urlLineText = lastChange.text[lastChange.text.length - 1];
-                        if (urlLineText.endsWith(EASYMDE_URL_PLACEHOLDER) && urlLineText !== '[]' + EASYMDE_URL_PLACEHOLDER) {
-                            const from = lastChange.from;
-                            const to = lastChange.to;
-                            const isSelectionMultiline = lastChange.text.length > 1;
-                            const baseIndex = isSelectionMultiline ? 0 : from.ch;
-                            // Everything works fine for the [Ctrl-K] case, but for the
-                            // [Button] case, this handler happens before the original
-                            // code, thus our change got wiped out.
-                            // Add a small delay to handle that case.
-                            setTimeout(() => {
-                                instance.setSelection(
-                                    { line: to.line, ch: baseIndex + urlLineText.lastIndexOf('(') + 1 },
-                                    { line: to.line, ch: baseIndex + urlLineText.lastIndexOf(')') }
-                                );
-                            }, 25);
+    <x-filament::input.wrapper>
+        <div
+            x-data="{ state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }}, editor: null }"
+            x-init="
+                editor = new EasyMDE({
+                    autoDownloadFontAwesome: false,
+                    element: $refs.editor,
+                    uploadImage: true,
+                    placeholder: @js(__($getPlaceholder() ?? 'Start writing…')),
+                    initialValue: state ?? '',
+                    spellChecker: false,
+                    autoSave: false,
+                    status: [{
+                        className: 'upload-image',
+                        defaultValue: ''
+                    }],
+                    toolbar: [
+                    @if($hasToolbarButton('heading'))
+                        'heading',
+                    @endif
+                    @if($hasToolbarButton('bold'))
+                        'bold',
+                    @endif
+                    @if($hasToolbarButton('italic'))
+                        'italic',
+                    @endif
+                    @if($hasToolbarButton('link'))
+                        'link',
+                    @endif
+                    @if($hasToolbarButton('quote'))
+                        'quote',
+                    @endif
+                    @if($hasToolbarButton('unordered-list'))
+                        'unordered-list',
+                    @endif
+                    @if($hasToolbarButton('ordered-list'))
+                        'ordered-list',
+                    @endif
+                    @if($hasToolbarButton('table'))
+                        'table',
+                    @endif
+                    @if($hasToolbarButton('upload-image'))
+                        {
+                            name: 'upload-image',
+                            action: EasyMDE.drawUploadedImage,
+                            className: 'fa fa-image',
+                        },
+                    @endif
+                    @if($hasToolbarButton('undo'))
+                        'undo',
+                    @endif
+                    @if($hasToolbarButton('redo'))
+                        { // When FontAwesome is not auto downloaded, this loads the correct icon
+                            name: 'redo',
+                            action: EasyMDE.redo,
+                            className: 'fa fa-redo',
+                            title: 'Redo',
+                        },
+                    @endif
+                    ],
+                    imageAccept: 'image/png, image/jpeg, image/gif, image/avif',
+                    imageUploadFunction: function(file, onSuccess, onError) {
+                        if (file.size > 1024 * 1024 * 2) {
+                            return onError('File cannot be larger than 2MB.');
                         }
+
+                        if (file.type.split('/')[0] !== 'image') {
+                            return onError('File must be an image.');
+                        }
+
+                        $wire.upload(`componentFileAttachments.{{ $getStatePath() }}`, file, () => {
+                            $wire.getFormComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
+                                if (! url) {
+                                    return onError('File could not be uploaded');
+                                }
+
+                                onSuccess(url);
+                            })
+                        });
+                    },
+                });
+
+                // 'Create Link (Ctrl-K)': highlight URL instead of label:
+                editor.codemirror.on('changes', (instance, changes) => {
+                    try {
+                        // Grab the last change from the buffered list. I assume the
+                        // buffered one ('changes', instead of 'change') is more efficient,
+                        // and that 'Create Link' will always end up last in the list.
+                        const lastChange = changes[changes.length - 1];
+                        if (lastChange.origin === '+input') {
+                            // https://github.com/Ionaru/easy-markdown-editor/blob/8fa54c496f98621d5f45f57577ce630bee8c41ee/src/js/easymde.js#L765
+                            const EASYMDE_URL_PLACEHOLDER = '(https://)';
+                            // The URL placeholder is always placed last, so just look at the
+                            // last text in the array to also cover the multi-line case:
+                            const urlLineText = lastChange.text[lastChange.text.length - 1];
+                            if (urlLineText.endsWith(EASYMDE_URL_PLACEHOLDER) && urlLineText !== '[]' + EASYMDE_URL_PLACEHOLDER) {
+                                const from = lastChange.from;
+                                const to = lastChange.to;
+                                const isSelectionMultiline = lastChange.text.length > 1;
+                                const baseIndex = isSelectionMultiline ? 0 : from.ch;
+                                // Everything works fine for the [Ctrl-K] case, but for the
+                                // [Button] case, this handler happens before the original
+                                // code, thus our change got wiped out.
+                                // Add a small delay to handle that case.
+                                setTimeout(() => {
+                                    instance.setSelection(
+                                        { line: to.line, ch: baseIndex + urlLineText.lastIndexOf('(') + 1 },
+                                        { line: to.line, ch: baseIndex + urlLineText.lastIndexOf(')') }
+                                    );
+                                }, 25);
+                            }
+                        }
+                    } catch (err) {
+                        // Do nothing (revert to original behavior)
                     }
-                } catch (err) {
-                    // Do nothing (revert to original behavior)
-                }
-            });
+                });
 
-            editor.codemirror.on('change', debounce(() => {
-                state = editor.value();
-            }));
+                editor.codemirror.on('change', debounce(() => {
+                    state = editor.value();
+                }));
 
-            $watch('state', () => {
-                if (editor.codemirror.hasFocus()) {
-                    return;
-                }
+                $watch('state', () => {
+                    if (editor.codemirror.hasFocus()) {
+                        return;
+                    }
 
-                editor.value(state ?? null);
-            });
-        "
-        wire:ignore
-    >
-        <textarea x-ref="editor"></textarea>
-    </div>
-</x-filament-forms::field-wrapper>
+                    editor.value(state ?? null);
+                });
+            "
+            wire:ignore
+        >
+            <textarea x-ref="editor"></textarea>
+        </div>
+    </x-filament::input.wrapper>
+</x-dynamic-component>

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -1,4 +1,4 @@
-<x-forms::field-wrapper
+<x-filament-forms::field-wrapper
     :id="$getId()"
     :label="$getLabel()"
     :label-sr-only="$isLabelHidden()"
@@ -154,4 +154,4 @@
     >
         <textarea x-ref="editor"></textarea>
     </div>
-</x-forms::field-wrapper>
+</x-filament-forms::field-wrapper>

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -4,7 +4,6 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
-    :hint-action="$getHintAction()"
     :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -91,7 +91,7 @@
                     }
 
                     $wire.upload(`componentFileAttachments.{{ $getStatePath() }}`, file, () => {
-                        $wire.getComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
+                        $wire.getFormComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
                             if (! url) {
                                 return onError('File could not be uploaded');
                             }

--- a/resources/views/markdownField.blade.php
+++ b/resources/views/markdownField.blade.php
@@ -13,6 +13,7 @@
 
     <x-filament::input.wrapper>
         <div
+            class="spatie-filament-markdown-editor"
             x-data="{ state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }}, editor: null }"
             x-init="
                 editor = new EasyMDE({

--- a/src/MarkdownEditorServiceProvider.php
+++ b/src/MarkdownEditorServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\FilamentMarkdownEditor;
 
-use Filament\Facades\Filament;
+use Filament\Support\Assets\Css;
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -16,16 +18,12 @@ class MarkdownEditorServiceProvider extends PackageServiceProvider
             ->hasViews();
     }
 
-    public function bootingPackage()
+    public function bootingPackage(): void
     {
-        Filament::registerScripts([
-            'spatie-markdown-editor' => __DIR__.'/../resources/dist/editor.js',
-        ], true);
-
-        Filament::registerStyles([
-            'https://pro.fontawesome.com/releases/v5.15.4/css/all.css',
-            'https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css',
-            'spatie-markdown-editor' => __DIR__.'/../resources/css/editor.css',
+        FilamentAsset::register([
+            Js::make('spatie-markdown-editor', __DIR__.'/../resources/dist/editor.js'),
+            Css::make('font-awesome', 'https://pro.fontawesome.com/releases/v5.15.4/css/all.css'),
+            Css::make('spatie-markdown-editor', __DIR__.'/../resources/css/editor.css'),
         ]);
     }
 }


### PR DESCRIPTION
Drops filament v2 support and performs some related housekeeping.

Some notes:

- First 2 commits taken from https://github.com/spatie/filament-markdown-editor/pull/26 by @mateusjunges. 2 after that rewritten. I have no access to that branch so simply cherrypicked the commits.
- Filament introduces their own markdown editor based on EasyMDE, including file uploads: https://filamentphp.com/docs/3.x/forms/fields/markdown-editor. From what I see there are some cosmetic differences but almost complete feature parity. I might switch to the filamentphp default one for my own projects just to reduce a dependency.
- There is a clash resulting in double icons. I fixed this clash by specifically removing the mask-image set by filament. Alternatively it's possible to actually let filament do these font inclusions and simply remove the font awesome dependency. I opted to solve the clash as it is less dependent on filament's own markdown editor implementation.

All in all, if someone can upgrade to filament v3 with this dependency they could probably remove it and switch to the filament provided one. In most cases anyway.

![Screenshot from 2024-03-29 11-52-17](https://github.com/spatie/filament-markdown-editor/assets/17289887/cb2f6d2b-9b8b-4ddd-b2ac-77ff3fc0c395)
